### PR TITLE
🧹 Remove unused DEL font character definition

### DIFF
--- a/examples/viewer/main.cpp
+++ b/examples/viewer/main.cpp
@@ -18,7 +18,7 @@ static const float PI = 3.14159265358979f;
 // ---------------------------------------------------------------------------
 // Tiny 5x7 bitmap font for the HUD overlay
 // Each char is 5 columns of 7 bits (LSB = top row).
-// Only ASCII 32-127 are stored; index = ch - 32.
+// Only ASCII 32-126 are stored; index = ch - 32.
 // ---------------------------------------------------------------------------
 static const uint8_t FONT5x7[][5] = {
     {0x00,0x00,0x00,0x00,0x00}, // ' '
@@ -116,7 +116,6 @@ static const uint8_t FONT5x7[][5] = {
     {0x00,0x00,0x7F,0x00,0x00}, // '|'
     {0x00,0x41,0x36,0x08,0x00}, // '}'
     {0x08,0x08,0x2A,0x1C,0x08}, // '~'
-    {0x08,0x1C,0x2A,0x08,0x08}, // DEL (unused)
 };
 
 // Draw a single character at pixel (px, py). Scale = pixel size of each font pixel.


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed the unused `DEL` character (ASCII 127) definition from the `FONT5x7` bitmap font array in `examples/viewer/main.cpp`.
- Updated the comment describing the array's supported character range.

💡 **Why:** How this improves maintainability
- Removes dead code that could cause confusion.
- Ensures the array size and the comment accurately reflect the range of characters handled by the rendering logic.

✅ **Verification:** How you confirmed the change is safe
- Verified `drawChar`'s bounds check in `examples/viewer/main.cpp` excludes ASCII 127.
- Successfully performed a partial compilation of the modified `main.cpp` using a mock SDL2 header to ensure no syntax errors.
- Confirmed the core `soft_render` library still builds correctly.

✨ **Result:** The improvement achieved
- Improved code clarity and reduced redundant data in the viewer example.

---
*PR created automatically by Jules for task [8285326267723505925](https://jules.google.com/task/8285326267723505925) started by @EricBorges2019*